### PR TITLE
Add basic code for the code generation related to QOS

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -5303,20 +5303,21 @@ public:
   friend class ASTStmtReader;
 };
 
+/// GVALLEE: I do not think this is the correct way to go
 class QOSKVExpr : public Expr {
-	private:
-		enum { PTR, ORDER, VAL1, ORDER_FAIL, VAL2, WEAK, END_EXPR };
-		Stmt *SubExprs[END_EXPR + 1];
-		unsigned NumSubExprs;
-		SourceLocation BuiltinLoc, RParenLoc;
+private:
+  enum { PTR, ORDER, VAL1, ORDER_FAIL, VAL2, WEAK, END_EXPR };
+  Stmt *SubExprs[END_EXPR + 1];
+  unsigned NumSubExprs;
+  SourceLocation BuiltinLoc, RParenLoc;
 
-		friend class ASTStmtReader;
-	public:
-		QOSKVExpr(SourceLocation BLoc, ArrayRef<Expr*> args, QualType t, SourceLocation RP);
+friend class ASTStmtReader;
+public:
+  QOSKVExpr(SourceLocation BLoc, ArrayRef<Expr*> args, QualType t, SourceLocation RP);
 
-		explicit QOSKVExpr(EmptyShell Empty) : Expr(QOSKVExprClass, Empty) { }
+  explicit QOSKVExpr(EmptyShell Empty) : Expr(QOSKVExprClass, Empty) { }
 
-		Expr *getPtr() const {
+  Expr *getPtr() const {
     return cast<Expr>(SubExprs[PTR]);
   }
   Expr *getOrder() const {

--- a/include/clang/Basic/OpenMPKinds.h
+++ b/include/clang/Basic/OpenMPKinds.h
@@ -164,6 +164,9 @@ bool isOpenMPTaskLoopDirective(OpenMPDirectiveKind DKind);
 /// parallel', otherwise - false.
 bool isOpenMPParallelDirective(OpenMPDirectiveKind DKind);
 
+/// GVALLEE: CHECKME
+bool isOpenMPQOSKVDirective(OpenMPDirectiveKind DKind);
+
 /// Checks if the specified directive is a target code offload directive.
 /// \param DKind Specified directive.
 /// \return true - the directive is a target code offload directive like

--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1994,9 +1994,11 @@ void StmtPrinter::VisitPseudoObjectExpr(PseudoObjectExpr *Node) {
   PrintExpr(Node->getSyntacticForm());
 }
 
+/// GVALLEE: i do not believe that this is the way to go
 void StmtPrinter::VisitQOSKVExpr(QOSKVExpr *Node)
 {
 	// GVALLEE: TODO
+	//PrintExpr(Node->getSyntacticForm());
 }
 
 void StmtPrinter::VisitAtomicExpr(AtomicExpr *Node) {

--- a/lib/AST/StmtProfile.cpp
+++ b/lib/AST/StmtProfile.cpp
@@ -1267,6 +1267,7 @@ void StmtProfiler::VisitPseudoObjectExpr(const PseudoObjectExpr *S) {
       Visit(OVE->getSourceExpr());
 }
 
+/// GVALLEE: I do not think this is the way to go
 void StmtProfiler::VisitQOSKVExpr(const QOSKVExpr *S)
 {
 	VisitExpr(S);

--- a/lib/Basic/OpenMPKinds.cpp
+++ b/lib/Basic/OpenMPKinds.cpp
@@ -803,6 +803,11 @@ bool clang::isOpenMPParallelDirective(OpenMPDirectiveKind DKind) {
          DKind == OMPD_target_teams_distribute_parallel_for_simd;
 }
 
+bool clang::isOpenMPQOSKVDirective(OpenMPDirectiveKind DKind)
+{
+	return DKind == OMPD_qoskv;
+}
+
 bool clang::isOpenMPTargetExecutionDirective(OpenMPDirectiveKind DKind) {
   return DKind == OMPD_target || DKind == OMPD_target_parallel ||
          DKind == OMPD_target_parallel_for ||
@@ -946,6 +951,9 @@ void clang::getOpenMPCaptureRegions(
     CaptureRegions.push_back(OMPD_teams);
     CaptureRegions.push_back(OMPD_parallel);
     break;
+  case OMPD_qoskv:
+    CaptureRegions.push_back(OMPD_qoskv);
+    break;
   case OMPD_simd:
   case OMPD_for:
   case OMPD_for_simd:
@@ -957,7 +965,6 @@ void clang::getOpenMPCaptureRegions(
   case OMPD_taskgroup:
   case OMPD_distribute:
   case OMPD_ordered:
-  case OMPD_qoskv:
   case OMPD_atomic:
   case OMPD_target_data:
   case OMPD_distribute_simd:

--- a/lib/CodeGen/CGOpenMPRuntime.h
+++ b/lib/CodeGen/CGOpenMPRuntime.h
@@ -758,6 +758,11 @@ public:
       const OMPExecutableDirective &D, const VarDecl *ThreadIDVar,
       OpenMPDirectiveKind InnermostKind, const RegionCodeGenTy &CodeGen);
 
+
+  virtual llvm::Value *emitQOSOutlinedFunction(
+  		  const OMPExecutableDirective &D, const VarDecl *ThreadIDVar,
+  		  OpenMPDirectiveKind InnermostKind, const RegionCodeGenTy &CodeGen);
+
   /// Emits outlined function for the specified OpenMP teams directive
   /// \a D. This outlined function has type void(*)(kmp_int32 *ThreadID,
   /// kmp_int32 BoundID, struct context_vars*).
@@ -809,6 +814,11 @@ public:
                                 llvm::Value *OutlinedFn,
                                 ArrayRef<llvm::Value *> CapturedVars,
                                 const Expr *IfCond);
+
+  /// GVALLEE: CHECKME
+  virtual void emitQOSKVCall(CodeGenFunction &CGF, SourceLocation Loc,
+                             llvm::Value *OutlinedFn,
+                             ArrayRef<llvm::Value *> CapturedVars);
 
   /// Emits a critical region.
   /// \param CriticalName Name of the critical region.

--- a/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
+++ b/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
@@ -731,6 +731,7 @@ static bool hasNestedSPMDDirective(ASTContext &Ctx,
     case OMPD_target_teams_distribute:
       return isOpenMPParallelDirective(DKind) &&
              !hasParallelIfNumThreadsClause(Ctx, *NestedDir);
+    case OMPD_qoskv:
     case OMPD_target_simd:
     case OMPD_target_parallel:
     case OMPD_target_parallel_for:
@@ -805,6 +806,7 @@ static bool supportsSPMDExecutionMode(ASTContext &Ctx,
   case OMPD_target_simd:
   case OMPD_target_teams_distribute_simd:
     return false;
+  case OMPD_qoskv:
   case OMPD_parallel:
   case OMPD_for:
   case OMPD_parallel_for:

--- a/lib/CodeGen/CGStmt.cpp
+++ b/lib/CodeGen/CGStmt.cpp
@@ -219,6 +219,9 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
   case Stmt::OMPCriticalDirectiveClass:
     EmitOMPCriticalDirective(cast<OMPCriticalDirective>(*S));
     break;
+  case Stmt::OMPQOSKVDirectiveClass:
+    EmitOMPQOSKVDirective(cast<OMPQOSKVDirective>(*S));
+    break;
   case Stmt::OMPParallelForDirectiveClass:
     EmitOMPParallelForDirective(cast<OMPParallelForDirective>(*S));
     break;

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -3092,6 +3092,7 @@ public:
   void EmitOMPSingleDirective(const OMPSingleDirective &S);
   void EmitOMPMasterDirective(const OMPMasterDirective &S);
   void EmitOMPCriticalDirective(const OMPCriticalDirective &S);
+  void EmitOMPQOSKVDirective(const OMPQOSKVDirective &S);
   void EmitOMPParallelForDirective(const OMPParallelForDirective &S);
   void EmitOMPParallelForSimdDirective(const OMPParallelForSimdDirective &S);
   void EmitOMPParallelSectionsDirective(const OMPParallelSectionsDirective &S);

--- a/lib/Sema/SemaOpenMP.cpp
+++ b/lib/Sema/SemaOpenMP.cpp
@@ -6200,6 +6200,7 @@ StmtResult Sema::ActOnOpenMPQOSKVDirective(ArrayRef<OMPClause *> Clauses,
 		SourceLocation StartLoc,
 		SourceLocation EndLoc)
 {
+	/// GVALLEE: CHECKME
 	if (!AStmt)
 		return StmtError();
 
@@ -6220,17 +6221,12 @@ StmtResult Sema::ActOnOpenMPQOSKVDirective(ArrayRef<OMPClause *> Clauses,
 	if (auto *EWC = dyn_cast<ExprWithCleanups>(Body))
 		Body = EWC->getSubExpr();
 
-//	Expr *X = nullptr;
-//	Expr *V = nullptr;
-//	Expr *E = nullptr;
-//	Expr *UE = nullptr;
-//	bool IsXLHSInRHSPart = false;
-//	bool IsPostfixUpdate = false;
-
+	/*
 	if (QOSKVKind == OMPC_resilience)
 	{
 		/// GVALLEE: TODO
 	}
+	*/
 
 	return OMPQOSKVDirective::Create (Context, StartLoc, EndLoc, Clauses, AStmt);
 }

--- a/lib/Serialization/ASTReaderStmt.cpp
+++ b/lib/Serialization/ASTReaderStmt.cpp
@@ -1001,6 +1001,7 @@ void ASTStmtReader::VisitPseudoObjectExpr(PseudoObjectExpr *E) {
   }
 }
 
+/// GVALLEE: I do not think this is the way to go
 void ASTStmtReader::VisitQOSKVExpr(QOSKVExpr *E)
 {
 	VisitExpr(E);

--- a/lib/Serialization/ASTWriterStmt.cpp
+++ b/lib/Serialization/ASTWriterStmt.cpp
@@ -945,6 +945,7 @@ void ASTStmtWriter::VisitPseudoObjectExpr(PseudoObjectExpr *E) {
   Code = serialization::EXPR_PSEUDO_OBJECT;
 }
 
+/// GVALLEE: I do not think this is the way to go
 void ASTStmtWriter::VisitQOSKVExpr(QOSKVExpr *E)
 {
 	VisitExpr(E);


### PR DESCRIPTION
Note that these modifications drop the content of QOS blocks.
There is really not much to review except make the group aware of the progresses and the code. It is still work in progress, the code is a little ugly but not uglier than the LLVM base code.